### PR TITLE
added the protocol to the ICXT hostname variable

### DIFF
--- a/001/icxt-sidebar.combined.js
+++ b/001/icxt-sidebar.combined.js
@@ -477,7 +477,7 @@ icxtbar.util.getNls = function (cb) {
     dojo.xhrGet(xhrArgs);
 };
 var icxtbar = icxtbar || {};
-icxtbar.host = 'eds-consak-01.org.rettigicc.net';
+icxtbar.host = 'https://eds-consak-01.org.rettigicc.net';
 icxtbar.actions = icxtbar.actions || [];
 icxtbar.nls = icxtbar.nls || {};
 


### PR DESCRIPTION
Customer sees errors while loading the `icxt-sidebar.css` file, due to the fact that the browser tries to resolve the file on the cloud server (apps.ce.collabserv.com/.../ic360/ui/api/res/cors/icxt-sidebar.css)